### PR TITLE
Provide method for listing scanner's static properties

### DIFF
--- a/DNTScanner.Core/SystemDevices.cs
+++ b/DNTScanner.Core/SystemDevices.cs
@@ -52,6 +52,34 @@ namespace DNTScanner.Core
             return scanners;
         }
 
+        /// <summary>
+        /// Lists the static properties of scanners connected to the system.
+        /// </summary>
+        public static List<IDictionary<string, object>> GetScannerDeviceProperties()
+        {
+            List<IDictionary<string, object>> properties = new List<IDictionary<string, object>>();
+            var deviceInfos = new DeviceManager().DeviceInfos;
+            foreach(DeviceInfo device in deviceInfos)
+            {
+                if (device.Type != WiaDeviceType.ScannerDeviceType)
+                {
+                    continue;
+                }
+
+                IDictionary<string, object> props = new Dictionary<string, object>();
+                foreach(Property item in device.Properties)
+                {
+                    props.Add(item.Name, item.get_Value());
+                }
+                properties.Add(props);
+
+                Marshal.FinalReleaseComObject(device);
+            }
+            Marshal.FinalReleaseComObject(deviceInfos);
+
+            return properties;
+        }
+
         private static IDictionary<string, string> getSupportedTransferFormats(Item scanner)
         {
             var results = new Dictionary<string, string>();


### PR DESCRIPTION
Hi, I have found that it can be useful to be able to quickly obtain a list of scanners and their basic properties from the WIA device manager. Instead of needing to connect to each scanner and enumerate the full properties, this simply provides the static properties of each device.

I would be grateful if you would be able to add this to the library so I can use it via your NuGet package!

Thanks for all your work on this, there are very few decent WIA libraries available